### PR TITLE
Remove redundant workspace entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
         "renderers/webgpuraytrace",
         "spec",
         "server",
-        "client",
-        "webgpuraytrace"
+        "client"
       ],
       "devDependencies": {
         "typescript": "^5.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "renderers/webgpuraytrace",
     "spec",
     "server",
-    "client",
-    "webgpuraytrace"
+    "client"
   ]
 }


### PR DESCRIPTION
The root package.json listed "webgpuraytrace" as a workspace, but no such directory exists. The package is already covered by the renderers/webgpuraytrace workspace entry.