### PR TITLE
Fix ambient type declarations for cross-environment builds

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Ambient declarations for globals available in both Node.js and browsers.
+
+declare var console: Console;
+
+interface Console {
+    log(...data: any[]): void;
+    warn(...data: any[]): void;
+    error(...data: any[]): void;
+}
+
+interface Performance {
+    now(): number;
+}
+
+declare var performance: Performance;
+
+declare function fetch(input: string, init?: any): Promise<Response>;
+
+interface Response {
+    readonly ok: boolean;
+    readonly statusText: string;
+    text(): Promise<string>;
+    json(): Promise<any>;
+    arrayBuffer(): Promise<ArrayBuffer>;
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -19,6 +19,8 @@
         "removeComments": true,
         "sourceMap": true,
         "strictFunctionTypes": true,
-        "target": "ES2017"
-    }
+        "target": "ES2017",
+        "types": []
+    },
+    "files": ["globals.d.ts"]
 }


### PR DESCRIPTION
Add files reference to globals.d.ts in tsconfig-base.json so console, performance, and fetch types resolve without relying on transitive @types/node inclusion.