### PR TITLE
Support 4K+ render resolutions

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -70,6 +70,7 @@ export class Main {
     // Renderer
     private _widthText: HTMLInputElement;
     private _heightText: HTMLInputElement;
+    private _refreshSizeRadioAvailability: () => void;
     private _renderer: WebGPURenderer.Main;
     private _startStopButton: HTMLButtonElement;
     private _maxSamplesText: HTMLInputElement;
@@ -233,6 +234,39 @@ export class Main {
         this._widthText = document.getElementById("widthText") as HTMLInputElement;
         this._heightText = document.getElementById("heightText") as HTMLInputElement;
         const resizeButton = document.getElementById("resizeButton") as HTMLButtonElement;
+        // Preset resolutions in pixels; "fit" and "custom" are computed at runtime.
+        const sizePresets: { [key: string]: { width: number, height: number } } = {
+            hd: { width: 1280, height: 720 },
+            fhd: { width: 1920, height: 1080 },
+            "4k": { width: 3840, height: 2160 },
+            "8k": { width: 7680, height: 4320 },
+        };
+        // Returns null if (width, height) is renderable; otherwise an error message describing the limit hit.
+        const checkRenderSize = (width: number, height: number): string | null => {
+            const maxPixels = this._renderer.maxPixels;
+            const maxDim = this._renderer.maxRenderDim;
+            // Over-dispatch by 1 in each axis for correct edge handling
+            const requested = (width + 1) * (height + 1);
+            if (width > maxDim || height > maxDim) {
+                return `${width}x${height}px exceeds device per-dimension limit of ${maxDim}px`;
+            }
+            if (requested > maxPixels) {
+                return `${width}x${height}px (${requested.toLocaleString()} pixels) exceeds device max of ${Math.floor(maxPixels).toLocaleString()} pixels (~${Math.floor(Math.sqrt(maxPixels)).toLocaleString()}px square or ${Math.floor(Math.sqrt(maxPixels * 16 / 9)).toLocaleString()}x${Math.floor(Math.sqrt(maxPixels * 9 / 16)).toLocaleString()} 16:9)`;
+            }
+            return null;
+        };
+        // Disable preset radios whose resolution exceeds device limits. Called after renderer init when limits are populated.
+        this._refreshSizeRadioAvailability = () => {
+            for (let i = 0; i < sizeRadioGroup.length; i++) {
+                const radio = sizeRadioGroup[i] as HTMLInputElement;
+                const preset = sizePresets[radio.value];
+                if (!preset) { continue; } // skip "fit" and "custom"
+                const err = checkRenderSize(preset.width, preset.height);
+                radio.disabled = err !== null;
+                const label = document.querySelector(`label[for="${radio.id}"]`) as HTMLLabelElement;
+                if (label) { label.style.opacity = err ? "0.4" : ""; }
+            }
+        };
         let sizeType: string;
         for (let i = 0; i < sizeRadioGroup.length; i++) {
             const sizeRadio = sizeRadioGroup[i] as HTMLInputElement;
@@ -252,33 +286,34 @@ export class Main {
         const sizeChanged = () => {
             let width: number;
             let height: number;
-            switch (sizeType) {
-                case "fit":
-                    const leftContainer = document.getElementById("leftContainer") as HTMLDivElement;
-                    width = leftContainer.clientWidth - 1; // -1 to avoid scrollbar
-                    height = leftContainer.clientHeight - 1; // -1 to avoid scrollbar
-                    break;
-                case "hd":
-                    width = 1280; height = 720;
-                    break;
-                case "fhd":
-                    width = 1920; height = 1080;
-                    break;
-                case "4k":
-                    width = 3840; height = 2160;
-                    break;
-                case "custom":
-                    width = parseInt(this._widthText.value);
-                    height = parseInt(this._heightText.value);
-                    if (isNaN(width) || isNaN(height)) {
-                        console.log("invalid size");
-                        return;
-                    }
-                    const maxBufferSize = Math.pow(2, 20) * 128 / 16; // 128MB buffer, 4 bytes/channel, 4 channels (3840x2160px 16:9, or 2,896px² square)
-                    if ((width + 1) * (height + 1) > maxBufferSize) { // Overdispatching for correct edge handling
-                        console.log(`${width}x${height}px buffer size ${(width + 1) * (height + 1)} bytes exceeds max ${maxBufferSize} bytes`);
-                        return;
-                    }
+            if (sizeType === "fit") {
+                const leftContainer = document.getElementById("leftContainer") as HTMLDivElement;
+                width = leftContainer.clientWidth - 1; // -1 to avoid scrollbar
+                height = leftContainer.clientHeight - 1; // -1 to avoid scrollbar
+            }
+            else if (sizeType === "custom") {
+                width = parseInt(this._widthText.value);
+                height = parseInt(this._heightText.value);
+                if (isNaN(width) || isNaN(height)) {
+                    console.log("invalid size");
+                    return;
+                }
+                const err = checkRenderSize(width, height);
+                if (err) {
+                    console.log(err);
+                    return;
+                }
+            }
+            else {
+                const preset = sizePresets[sizeType];
+                if (!preset) { return; }
+                width = preset.width;
+                height = preset.height;
+                const err = checkRenderSize(width, height);
+                if (err) {
+                    console.log(err);
+                    return;
+                }
             }
             this._resize(width, height);
         };
@@ -389,6 +424,9 @@ export class Main {
             this._startStopButton.disabled = true;
             return;
         }
+
+        // Renderer device limits are now populated; gray out preset sizes that exceed them.
+        this._refreshSizeRadioAvailability();
 
         console.log(`client initialized ${Core.Time.formatDuration((performance.now() - start))}`);
     }

--- a/client/wwwroot/client.html
+++ b/client/wwwroot/client.html
@@ -419,6 +419,8 @@
                                         for="sizeFullHd" title="1920x1080" class="radioLabel">Full HD</label></div>
                                 <div><input type="radio" name="sizeRadioGroup" id="size4k" value="4k" /><label
                                         for="size4k" title="3840x2160" class="radioLabel">4K</label></div>
+                                <div><input type="radio" name="sizeRadioGroup" id="size8k" value="8k" /><label
+                                        for="size8k" title="7680x4320" class="radioLabel">8K</label></div>
                                 <div style="display: flex; flex-direction: row; gap: 8px; align-items: baseline;">
                                     <div><input type="radio" name="sizeRadioGroup" value="custom"
                                             id="sizeCustom" /><label for="sizeCustom" class="radioLabel">Custom</label>

--- a/core/src/bvh.ts
+++ b/core/src/bvh.ts
@@ -172,8 +172,20 @@ export class BVHAccel {
                     case "sah":
                     default:
                         // Partition primitives using approximate SAH
-                        if (nPrimitives <= 4) {
-                            // Partition primitives into equally sized subsets (SplitMethod.equalCounts)
+                        if (nPrimitives <= this._maxPrimsInNode) {
+                            // Few enough primitives to fit in a leaf — stop splitting
+                            const firstPrimOffset = this._orderedPrimitives.length;
+                            for (let i = start; i < end; i++) {
+                                const primNum = this._primitiveInfo[i].primitiveNumber;
+                                this._orderedPrimitivesLookup[this._orderedPrimitives.length] = primNum;
+                                this._orderedPrimitives.push(this._primitives[primNum]);
+                            }
+                            node.initLeaf(firstPrimOffset, nPrimitives, bounds);
+                            return node;
+                        } else if (nPrimitives <= 4) {
+                            // Only reachable when maxPrimsInNode < 4 (the leaf check above otherwise
+                            // catches all small nodes). For 2-4 primitives, SAH bucketing across 12
+                            // buckets isn't meaningful, so split by equal counts instead.
                             mid = Math.floor((start + end) / 2);
                             // Sort subset
                             const primitiveInfo = this._primitiveInfo.slice(start, end);

--- a/core/src/renderer.ts
+++ b/core/src/renderer.ts
@@ -46,6 +46,15 @@ export abstract class Renderer {
     // BVH
     public maxPrimsInNode: number;
 
+    // Render-size capabilities (set by concrete renderers after device init).
+    // Default: no limit. WebGPU subclass derives these from device limits.
+    protected _maxPixels: number = Number.POSITIVE_INFINITY;
+    protected _maxRenderDim: number = Number.POSITIVE_INFINITY;
+    /** Max total pixels per render, including any over-dispatch padding. Concrete renderers populate this from their backend's buffer/memory limits. */
+    public get maxPixels(): number { return this._maxPixels; }
+    /** Max pixels per render axis (width or height). Concrete renderers populate this from their backend's per-axis dispatch or framebuffer limits. */
+    public get maxRenderDim(): number { return this._maxRenderDim; }
+
     // Lighting
     protected _ambientColor: ColorRGB;
     protected _ambientColorLinear: ColorRGB;
@@ -304,7 +313,7 @@ export abstract class Renderer {
         this._transitionTime = 1;
 
         // BVH
-        this.maxPrimsInNode = 1;
+        this.maxPrimsInNode = 4;
 
         // Lighting
         this.ambientColor = vector3.clone(Config.ambientColor);

--- a/renderers/webgpuraytrace/src/main.ts
+++ b/renderers/webgpuraytrace/src/main.ts
@@ -139,18 +139,35 @@ export class Main extends Core.Renderer {
             if (this._adapter.features.has("timestamp-query")) {
                 requiredFeatures.push("timestamp-query");
             }
+            const limits = this._adapter.limits;
             const gpuDeviceDescriptor: GPUDeviceDescriptor = {
                 requiredFeatures,
                 requiredLimits: {
-                    // Max storage buffer size
-                    maxStorageBufferBindingSize: 134217728,
+                    // Buffers (overall size and binding size as a storage buffer) — request adapter max
+                    maxBufferSize: limits.maxBufferSize,
+                    maxStorageBufferBindingSize: limits.maxStorageBufferBindingSize,
 
-                    // Match workgroups per dimension to shader
-                    maxComputeWorkgroupsPerDimension: 256,
+                    // Compute dispatch cap — request adapter max so high-resolution
+                    // renders aren't silently truncated. With a 16x16 workgroup,
+                    // each dispatch dimension allows up to 16 * limit pixels.
+                    maxComputeWorkgroupsPerDimension: limits.maxComputeWorkgroupsPerDimension,
                 }
             };
             this._device = await this._adapter.requestDevice(gpuDeviceDescriptor);
             this._maxComputeWorkgroupsPerDimension = this._device.limits.maxComputeWorkgroupsPerDimension;
+
+            // Derive render-size limits from device.
+            // maxPixels: dominated by the output color buffer (16 B/pixel = 4 channels × 4 bytes).
+            //   The buffer is bound for storage, so the limit is min(maxBufferSize, maxStorageBufferBindingSize).
+            //   Subtract a padding band (maxEdgeThickness²) to account for edge-detection over-dispatch.
+            // maxRenderDim: each compute dispatch can be at most maxComputeWorkgroupsPerDimension workgroups
+            //   along an axis; the workgroup is 16×16, so the per-axis pixel limit is 16× that.
+            const deviceLimits = this._device.limits;
+            const bytesPerPixel = 16;
+            const maxBufferPixels = Math.min(deviceLimits.maxBufferSize, deviceLimits.maxStorageBufferBindingSize) / bytesPerPixel;
+            const padding = Core.Config.maxEdgeThickness;
+            this._maxPixels = Math.max(0, Math.floor(maxBufferPixels - padding * padding));
+            this._maxRenderDim = this._maxComputeWorkgroupsPerDimension * 16;
             this._queue = this._device.queue;
             this._context = this._canvas.getContext("webgpu");
             if (!this._context) { throw new Error("WebGPU canvas context not available"); }

--- a/renderers/webgpuraytrace/src/shaders/pathtrace.ts
+++ b/renderers/webgpuraytrace/src/shaders/pathtrace.ts
@@ -1734,7 +1734,8 @@ fn main(@builtin(global_invocation_id) globalId : vec3<u32>) {
     var normal = vec3<f32>(0f, 0f, 0f);
     
     // Seed random number generator per pixel
-    var seed = u32(tilePixelY * tileSize.x + tilePixelX) + frameSeed * u32(tileSize.x * tileSize.y);
+    // Compute the per-pixel seed in u32 to avoid f32 mantissa precision loss above 2^24 pixels (~16.7M, e.g. row >2184 at 7680px wide)
+    var seed = (globalId.y * u32(tileSize.x) + globalId.x) + frameSeed * (u32(tileSize.x) * u32(tileSize.y));
 
     // Sample position (sub-pixel sampling has same seed, but only sampled once per frame)
     let samplePos = vec2<f32>(texCoord) + vec2<f32>(random(&seed), random(&seed)) / imageSize;
@@ -1781,8 +1782,9 @@ fn color(@builtin(global_invocation_id) globalId : vec3<u32>) {
     let texCoord = vec2<f32>(imagePixelX / imageSize.x, imagePixelY / imageSize.y);
 
     // Seed random number generator per pixel
+    // Compute the per-pixel seed in u32 to avoid f32 mantissa precision loss above 2^24 pixels (~16.7M, e.g. row >2184 at 7680px wide)
     var frameSeed = u32(uniforms.seed);
-    var seed = u32(tilePixelY * tileSize.x + tilePixelX) + frameSeed * u32(tileSize.x * tileSize.y);
+    var seed = (globalId.y * u32(tileSize.x) + globalId.x) + frameSeed * (u32(tileSize.x) * u32(tileSize.y));
 
     // Sample position (random sub-pixel jitter)
     let samplePos = vec2<f32>(texCoord) + vec2<f32>(random(&seed), random(&seed)) / imageSize;

--- a/renderers/webgpuraytrace/src/shaders/quad.ts
+++ b/renderers/webgpuraytrace/src/shaders/quad.ts
@@ -43,9 +43,9 @@ fn vert_main(@builtin(vertex_index) vertexIndex : u32) -> VertexOutput {
 
 @fragment
 fn frag_main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
-    let x = floor(coord.x);
-    let y = floor(coord.y);
-    let index = u32(x + y * (uniforms.bufferStride)) * 4u;
+    let x = u32(floor(coord.x));
+    let y = u32(floor(coord.y));
+    let index = (x + y * u32(uniforms.bufferStride)) * 4u;
     // [0,1]
     var color = vec3<f32>(colorBuffer.data[index], colorBuffer.data[index + 1u], colorBuffer.data[index + 2u]) / uniforms.samplesPerPixel;
     // return vec4<f32>(color, 1f);
@@ -59,9 +59,9 @@ fn frag_main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
 
 @fragment
 fn frag_normal(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
-    let x = floor(coord.x);
-    let y = floor(coord.y);
-    let index = u32(x + y * (uniforms.bufferStride)) * 4u;
+    let x = u32(floor(coord.x));
+    let y = u32(floor(coord.y));
+    let index = (x + y * u32(uniforms.bufferStride)) * 4u;
     // [0,1]
     // TODO: Convert from [-1,1] to [0,1] here instead of in the shader
     var normal = vec3<f32>(colorBuffer.data[index], colorBuffer.data[index + 1u], colorBuffer.data[index + 2u]) / uniforms.samplesPerPixel;
@@ -70,9 +70,9 @@ fn frag_normal(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
 
 @fragment
 fn frag_depth(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
-    let x = floor(coord.x);
-    let y = floor(coord.y);
-    let index = u32(x + y * (uniforms.bufferStride)) * 4u;
+    let x = u32(floor(coord.x));
+    let y = u32(floor(coord.y));
+    let index = (x + y * u32(uniforms.bufferStride)) * 4u;
     let depth = colorBuffer.data[index + 3u] / uniforms.samplesPerPixel;
     let minDepth = uniforms.minDepth;
     let maxDepth = uniforms.maxDepth;
@@ -94,9 +94,9 @@ fn frag_depth(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
 
 @fragment
 fn frag_segment(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
-    let x = floor(coord.x);
-    let y = floor(coord.y);
-    let index = u32(x + y * (uniforms.bufferStride)) * 4u;
+    let x = u32(floor(coord.x));
+    let y = u32(floor(coord.y));
+    let index = (x + y * u32(uniforms.bufferStride)) * 4u;
     var color = vec3<f32>(colorBuffer.data[index], colorBuffer.data[index + 1u], colorBuffer.data[index + 2u]) / uniforms.samplesPerPixel;
     return vec4<f32>(color, 1f);
 }


### PR DESCRIPTION
Lifts several limits that silently truncated or corrupted renders above 4K, adds device-derived capability surfacing, and adds an 8K preset.
 - Request adapter-max for maxBufferSize, maxStorageBufferBindingSize, and maxComputeWorkgroupsPerDimension. Previously hardcoded to 128 MB / 256  workgroups, capping renders at ~4K and silently cropping anything above.
 - Reduce BVH node count via maxPrimsInNode default 1 → 4 (PBRT precedent). Adds leaf-branch in BVH SAH path that creates a leaf when nPrimitives ≤ maxPrimsInNode, bypassing the equalCounts fallback. Roughly 3× node reduction on dense scenes.
 - Fix f32 mantissa precision bug in pixel/buffer index arithmetic. At 8K, y * bufferStride exceeded 2^24 around row 2183, collapsing groups of adjacent pixels onto the same buffer slot. Compute indices in u32 end-to-end in pathtrace.ts (seed) and quad.ts (output readback).
 - Surface device limits via Renderer.maxPixels and Renderer.maxRenderDim. Client uses these to gate custom-resolution input, gray out preset radios exceeding device limits, and produce error messages with actual maxima.
 - Add 8K (7680x4320) preset radio to client UI.